### PR TITLE
Updated HyScale Entries in landscape.yml

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -2477,10 +2477,13 @@ landscape:
             logo: harness.svg
             crunchbase: 'https://www.crunchbase.com/organization/harness-512d'
           - item:
-            name: HyScale
-            homepage_url: 'https://www.hyscale.io/'
+            name: HyScale Enterprise
+            description: >-
+              An acceleration platform for Kubernetes. Offers self-service app deployments, container sprawl management across clusters, and DevSecOps.
+            homepage_url: 'https://www.hyscale.io/enterprise'
             logo: hyscale.svg
             crunchbase: 'https://www.crunchbase.com/organization/hyscale'
+            twitter: 'https://twitter.com/hyscaleio/'
           - item:
             name: Jenkins
             homepage_url: 'https://jenkins.io/'

--- a/landscape.yml
+++ b/landscape.yml
@@ -2165,6 +2165,15 @@ landscape:
             twitter: 'https://twitter.com/helmpack'
             crunchbase: 'https://www.crunchbase.com/organization/cloud-native-computing-foundation'
           - item:
+            name: HyScale
+            description: >-
+              HyScale defines an app-centric declarative spec for service configs & provides an abstraction framework over Kubernetes for app deployment,
+              runtime ops and deployment troubleshooting.
+            homepage_url: 'https://www.hyscale.io/'
+            repo_url: 'https://github.com/hyscale/hyscale'
+            logo: hyscale.svg
+            twitter: 'https://twitter.com/hyscaleio/'
+          - item:
             name: kaniko
             homepage_url: 'https://github.com/GoogleContainerTools/kaniko'
             repo_url: 'https://github.com/GoogleContainerTools/kaniko'


### PR DESCRIPTION
1. Updated Existing HyScale Enterprise entry in "Continuous Integration & Delivery" subcategory
2. Added new HyScale opensource tool entry in subcategory of "Application Definition & Image Build"

### Pre-submission checklist:

*Please check each of these after submitting your pull request:*

* [x] Are you only including a `repo_url` if your project is 100% open source? If so, you need to pick the single best GitHub repository for your project, not a GitHub organization.
* [x] Is your project closed source or, if it is open source, does your project have at least 300 GitHub stars?
* [x] Have you picked the single best (existing) category for your project?
* [x] Does it follow the other guidelines from the [new entries](https://github.com/cncf/landscape#new-entries) section?
* [x] Have you included a URL for your SVG or added it to `hosted_logos` and referenced it there?
* [x] Does your logo clearly state the name of the project/product and follow the other logo [guidelines](https://github.com/cncf/landscape#logos)?
* [x] Does your project/product name match the text on the logo?
* [x] Have you verified that the Crunchbase data for your organization is correct (including headquarters and LinkedIn)?
* [x] ~15 minutes after opening the pull request, the CNCF-Bot will post the URL for your staging server. Have you confirmed that it looks good to you and then added a comment to the PR saying "LGTM"?
